### PR TITLE
feat: add automatic class sorting with prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-	"plugins": ["prettier-plugin-astro"],
+	"plugins": ["prettier-plugin-astro", "prettier-plugin-tailwindcss"],
 	"overrides": [
 		{
 			"files": "*.astro",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"eslint-plugin-jsx-a11y": "^6.10.2",
 				"eslint-plugin-simple-import-sort": "^12.1.1",
 				"prettier": "^3.5.3",
-				"prettier-plugin-astro": "0.14.1",
+				"prettier-plugin-astro": "^0.14.1",
 				"prettier-plugin-tailwindcss": "^0.6.11",
 				"typescript-eslint": "^8.26.1"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,9 @@
 				"eslint-plugin-eslint-comments": "^3.2.0",
 				"eslint-plugin-jsx-a11y": "^6.10.2",
 				"eslint-plugin-simple-import-sort": "^12.1.1",
-				"prettier": "3.5.3",
+				"prettier": "^3.5.3",
 				"prettier-plugin-astro": "0.14.1",
+				"prettier-plugin-tailwindcss": "^0.6.11",
 				"typescript-eslint": "^8.26.1"
 			}
 		},
@@ -6390,6 +6391,84 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/prettier-plugin-tailwindcss": {
+			"version": "0.6.11",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.11.tgz",
+			"integrity": "sha512-YxaYSIvZPAqhrrEpRtonnrXdghZg1irNg4qrjboCXrpybLWVs55cW2N3juhspVJiO0JBvYJT8SYsJpc8OQSnsA==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"peerDependencies": {
+				"@ianvs/prettier-plugin-sort-imports": "*",
+				"@prettier/plugin-pug": "*",
+				"@shopify/prettier-plugin-liquid": "*",
+				"@trivago/prettier-plugin-sort-imports": "*",
+				"@zackad/prettier-plugin-twig": "*",
+				"prettier": "^3.0",
+				"prettier-plugin-astro": "*",
+				"prettier-plugin-css-order": "*",
+				"prettier-plugin-import-sort": "*",
+				"prettier-plugin-jsdoc": "*",
+				"prettier-plugin-marko": "*",
+				"prettier-plugin-multiline-arrays": "*",
+				"prettier-plugin-organize-attributes": "*",
+				"prettier-plugin-organize-imports": "*",
+				"prettier-plugin-sort-imports": "*",
+				"prettier-plugin-style-order": "*",
+				"prettier-plugin-svelte": "*"
+			},
+			"peerDependenciesMeta": {
+				"@ianvs/prettier-plugin-sort-imports": {
+					"optional": true
+				},
+				"@prettier/plugin-pug": {
+					"optional": true
+				},
+				"@shopify/prettier-plugin-liquid": {
+					"optional": true
+				},
+				"@trivago/prettier-plugin-sort-imports": {
+					"optional": true
+				},
+				"@zackad/prettier-plugin-twig": {
+					"optional": true
+				},
+				"prettier-plugin-astro": {
+					"optional": true
+				},
+				"prettier-plugin-css-order": {
+					"optional": true
+				},
+				"prettier-plugin-import-sort": {
+					"optional": true
+				},
+				"prettier-plugin-jsdoc": {
+					"optional": true
+				},
+				"prettier-plugin-marko": {
+					"optional": true
+				},
+				"prettier-plugin-multiline-arrays": {
+					"optional": true
+				},
+				"prettier-plugin-organize-attributes": {
+					"optional": true
+				},
+				"prettier-plugin-organize-imports": {
+					"optional": true
+				},
+				"prettier-plugin-sort-imports": {
+					"optional": true
+				},
+				"prettier-plugin-style-order": {
+					"optional": true
+				},
+				"prettier-plugin-svelte": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/prismjs": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
 		"eslint-plugin-eslint-comments": "^3.2.0",
 		"eslint-plugin-jsx-a11y": "^6.10.2",
 		"eslint-plugin-simple-import-sort": "^12.1.1",
-		"prettier": "3.5.3",
+		"prettier": "^3.5.3",
 		"prettier-plugin-astro": "0.14.1",
+		"prettier-plugin-tailwindcss": "^0.6.11",
 		"typescript-eslint": "^8.26.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"eslint-plugin-jsx-a11y": "^6.10.2",
 		"eslint-plugin-simple-import-sort": "^12.1.1",
 		"prettier": "^3.5.3",
-		"prettier-plugin-astro": "0.14.1",
+		"prettier-plugin-astro": "^0.14.1",
 		"prettier-plugin-tailwindcss": "^0.6.11",
 		"typescript-eslint": "^8.26.1"
 	}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -20,7 +20,7 @@ const { title, description } = Astro.props;
 		<MainHead title={title} description={description} />
 	</head>
 	<body>
-		<div class="flex flex-col backgrounds">
+		<div class="backgrounds flex flex-col">
 			<Nav />
 			<slot />
 			<Footer />

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -45,7 +45,7 @@ const { Content } = await render(entry);
 				</div>
 			</header>
 			<main class="wrapper">
-				<div class="flex flex-col gap-10 content">
+				<div class="content flex flex-col gap-10">
 					{entry.data.img && <img src={entry.data.img} alt={entry.data.img_alt || ""} />}
 					<div class="content">
 						<Content />


### PR DESCRIPTION
Add automatic class sorting with Prettier - via `prettier-plugin-tailwindcss` ([docs](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier)).